### PR TITLE
Uncertainty table fixes

### DIFF
--- a/table_definitions/uncertainty_table.csv
+++ b/table_definitions/uncertainty_table.csv
@@ -1,8 +1,8 @@
 # Description:
 # Source:
 element_name	kind	external_table	description
-observation_id	varchar	observations_table:observation_id	Link to observation this entry is for
-uncertainty_type	int	uncertainty_type:type	Type of uncertainty described by this entry
+observation_id	varchar (pk)	observations_table:observation_id	Link to observation this entry is for
+uncertainty_type	int (pk)	uncertainty_type:type	Type of uncertainty described by this entry
 uncertainty_method	int	uncertainty_method:method	Method used to estimate this uncertainty
 uncertainty_value	numeric	 	Expected error standard deviation due to specified uncerainty source
 uncertainty_units	int	units:units	The units used to report the uncertainty. This may be different to the reporting units (e.g. \%)

--- a/table_definitions/uncertainty_table.csv
+++ b/table_definitions/uncertainty_table.csv
@@ -2,7 +2,7 @@
 # Source:
 element_name	kind	external_table	description
 observation_id	varchar	observations_table:observation_id	Link to observation this entry is for
-uncertainty_type	int	uncertainty_type.type	Type of uncertainty described by this entry
+uncertainty_type	int	uncertainty_type:type	Type of uncertainty described by this entry
 uncertainty_method	int	uncertainty_method:method	Method used to estimate this uncertainty
 uncertainty_value	numeric	 	Expected error standard deviation due to specified uncerainty source
 uncertainty_units	int	units:units	The units used to report the uncertainty. This may be different to the reporting units (e.g. \%)


### PR DESCRIPTION
* Fixed typo (a "." that should be a ":").
* Added missing (pk) so primary keys are defined.